### PR TITLE
Corrected typedef so that map value_type and allocator are the same (…

### DIFF
--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -47,7 +47,7 @@ public:
 
     typedef pair<set<KeyFrame*>,int> ConsistentGroup;    
     typedef map<KeyFrame*,g2o::Sim3,std::less<KeyFrame*>,
-        Eigen::aligned_allocator<std::pair<const KeyFrame*, g2o::Sim3> > > KeyFrameAndPose;
+        Eigen::aligned_allocator<std::pair<KeyFrame* const, g2o::Sim3> > > KeyFrameAndPose;
 
 public:
 


### PR DESCRIPTION
…KeyFrameAndPose)